### PR TITLE
Support proj8 in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AC_ARG_ENABLE(proj, AC_HELP_STRING([--disable-proj],
 AM_CONDITIONAL(PROJ, test "x$enableval" = "xyes")
 
 if test "x$enableval" = "xyes"; then
-AC_CHECK_LIB([proj], [pj_init],
+AC_CHECK_LIB([proj], [proj_info],
  proj=yes
  PROJ_LIBS="-lproj"
  AC_SUBST(PROJ_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -57,12 +57,17 @@ AC_ARG_ENABLE(proj, AC_HELP_STRING([--disable-proj],
 AM_CONDITIONAL(PROJ, test "x$enableval" = "xyes")
 
 if test "x$enableval" = "xyes"; then
-AC_CHECK_LIB([proj], [proj_info],
- proj=yes
- PROJ_LIBS="-lproj"
- AC_SUBST(PROJ_LIBS)
- AC_DEFINE(HAVE_LIBPROJ, 1, [Enable proj]),
- AC_MSG_ERROR([proj library not found]), )
+    AC_CHECK_LIB([proj], [pj_init], [proj=yes], [proj=no])
+    if test x$proj = xno; then
+        AC_CHECK_LIB([proj], [proj_info], [proj=yes], [proj=no])
+    fi
+    if test x$proj = xyes; then
+        PROJ_LIBS="-lproj"
+        AC_SUBST(PROJ_LIBS)
+        AC_DEFINE(HAVE_LIBPROJ, 1, [Enable proj])
+    else
+        AC_MSG_ERROR([proj library not found])
+    fi
 fi
 
 AC_ARG_ENABLE(shapelib, AC_HELP_STRING([--disable-shapelib],


### PR DESCRIPTION
If `pj_init` is not found, then `AC_CHECK_LIB` looks for `proj_info`.

Tested in https://simc.arpae.it/moncic-ci/fortrangis/202208241050/issue15/ (Fedora 36 build fails during compilation after checking for proj library).

Fix #15 